### PR TITLE
Fix repeated creation of mock location provider

### DIFF
--- a/app/src/main/java/amotz/example/com/mocklocationfordeveloper/adbBrodcastReceiver.java
+++ b/app/src/main/java/amotz/example/com/mocklocationfordeveloper/adbBrodcastReceiver.java
@@ -20,16 +20,22 @@ public class adbBrodcastReceiver extends BroadcastReceiver {
 
 
         if (intent.getAction().equals("stop.mock")) {
-            if (mockGPS!=null) {
+            if (mockGPS != null) {
                 mockGPS.shutdown();
+                mockGPS = null;
             }
-            if (mockWifi!=null) {
+            if (mockWifi != null) {
                 mockWifi.shutdown();
+                mockWifi = null;
             }
         }
         else {
-            mockGPS = new MockLocationProvider(LocationManager.GPS_PROVIDER, context);
-            mockWifi = new MockLocationProvider(LocationManager.NETWORK_PROVIDER, context);
+            if (mockGPS == null) {
+                mockGPS = new MockLocationProvider(LocationManager.GPS_PROVIDER, context);
+            }
+            if (mockWifi == null) {
+                mockWifi = new MockLocationProvider(LocationManager.NETWORK_PROVIDER, context);
+            }
 
             double lat, lon, alt;
             float accurate;


### PR DESCRIPTION
## Summary
- prevent broadcast receiver from recreating location providers repeatedly
- clean up providers on stop action

## Testing
- `./gradlew test` *(fails: Could not resolve com.android.tools.build:gradle:2.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_684030c20a7883269f4a6a403620520a